### PR TITLE
Ls cd

### DIFF
--- a/CLI/build.gradle
+++ b/CLI/build.gradle
@@ -29,12 +29,10 @@ run {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation(
-            'junit:junit:4.12',
             'org.junit.jupiter:junit-jupiter-api:5.4.2'
     )
     testRuntime(
-            'org.junit.jupiter:junit-jupiter-engine:5.4.2',
-            'org.junit.vintage:junit-vintage-engine:5.4.2'
+            'org.junit.jupiter:junit-jupiter-engine:5.4.2'
     )
 }
 

--- a/CLI/src/main/kotlin/Environment.kt
+++ b/CLI/src/main/kotlin/Environment.kt
@@ -1,6 +1,7 @@
 package com.sd.hw
 
 import java.io.File
+import java.security.InvalidParameterException
 
 /**
  * Class for storing one command or pipeline execution result.
@@ -20,6 +21,12 @@ class Environment {
 
     private val vars: MutableMap<String, String> = mutableMapOf()
     private val parser = Parser(OperationFactory(this), this)
+    var workingDirectory: File = File(".").absoluteFile
+        set(newDir) {
+            if (!newDir.isDirectory)
+                throw InvalidParameterException("$newDir not a directory")
+            field = newDir
+        }
 
     /**
      * Execute pipeline of bash commands.
@@ -60,7 +67,7 @@ class Environment {
      * Get file text or null if such file does not exist.
      */
     fun resolveFile(filename: String): String? {
-        val file = File(filename)
+        val file = workingDirectory.resolve(filename)
         if (!file.exists()) {
             return null
         }
@@ -68,10 +75,10 @@ class Environment {
     }
 
     /**
-     * Get file absolute path.
+     * Get file canonical path.
      */
     fun getFullFilePath(filename: String): String {
-        val file = File(filename)
-        return file.absolutePath
+        val file = workingDirectory.resolve(filename)
+        return file.canonicalPath
     }
 }

--- a/CLI/src/main/kotlin/Operation.kt
+++ b/CLI/src/main/kotlin/Operation.kt
@@ -150,7 +150,7 @@ class RunProcess(private  val name: String, environment: Environment) : Operatio
 //        println(args)
         try {
             val process = ProcessBuilder(args)
-                .directory(File("."))
+                .directory(environment.workingDirectory)
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectError(ProcessBuilder.Redirect.PIPE)
                 .start()

--- a/CLI/src/main/kotlin/Operation.kt
+++ b/CLI/src/main/kotlin/Operation.kt
@@ -87,6 +87,46 @@ class Cat(environment: Environment) : Operation(environment) {
 }
 
 /**
+ * Class for cd bash command partial simulation.
+ */
+class CD(environment: Environment) : Operation(environment) {
+    /**
+     * Change working directory.
+     */
+    override fun run(additionalInput: String?): ExecutionResult {
+        if (args.isNotEmpty()) {
+            val filename = args[0]
+            val newPath = environment.workingDirectory.resolve(filename)
+            if (!newPath.exists() || !newPath.isDirectory) {
+                return ExecutionResult(true, "No directory named $filename found")
+            }
+            environment.workingDirectory = environment.workingDirectory.resolve(filename)
+        }
+        return ExecutionResult(false, "")
+    }
+}
+
+/**
+ * Class for ls bash command partial simulation.
+ */
+class LS(environment: Environment) : Operation(environment) {
+    /**
+     * Returns list of files in the given directory (the current is default).
+     */
+    override fun run(additionalInput: String?): ExecutionResult {
+        val path = if (args.isNotEmpty()) args[0] else "."
+
+        val pathToTarget = environment.workingDirectory.resolve(path)
+        if (!pathToTarget.exists() || !pathToTarget.isDirectory) {
+            return ExecutionResult(true, "No directory named $path found")
+        }
+        val filesList = pathToTarget.listFiles() ?: return ExecutionResult(true, "Can not read from $path")
+        val result = filesList.joinToString("\n") { it.name }
+        return ExecutionResult(false, result)
+    }
+}
+
+/**
  * Class for exit bash command partial simulation.
  */
 class Exit(environment: Environment) : Operation(environment) {
@@ -168,6 +208,8 @@ class OperationFactory(private val environment: Environment) {
             "cat" -> Cat(environment)
             "exit" -> Exit(environment)
             "=" -> Association(environment)
+            "cd" -> CD(environment)
+            "ls" -> LS(environment)
             else -> RunProcess(name, environment)
         }
     }

--- a/CLI/src/test/kotlin/EnvironmentTest.kt
+++ b/CLI/src/test/kotlin/EnvironmentTest.kt
@@ -1,8 +1,8 @@
 package com.sd.hw
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class EnvironmentTest {

--- a/CLI/src/test/kotlin/OperationTest.kt
+++ b/CLI/src/test/kotlin/OperationTest.kt
@@ -230,4 +230,57 @@ internal class OperationTest {
         assertTrue(result.isInterrupted)
         assertTrue(result.textResult.contains("java.io.IOException: Cannot run program \"ichi\""))
     }
+
+    @Test
+    fun lsCurrentTest() {
+        val ls = LS(environment)
+
+        val result = ls.run()
+        assertEquals(false, result.isInterrupted)
+        assertEquals(File(".").listFiles()!!.joinToString("\n") { it.name }, result.textResult)
+    }
+
+    @Test
+    fun lsEmptySubDirTest() {
+        val ls = LS(environment)
+
+        file = File("kek")
+        file.mkdir()
+
+        val result = ls.withArgs(listOf("kek")).run()
+        assertEquals(false, result.isInterrupted)
+        assertEquals(File("./kek").listFiles()!!.joinToString("\n") { it.name }, result.textResult)
+    }
+
+    @Test
+    fun lsNotExistedSubDirTest() {
+        val ls = LS(environment)
+
+        val result = ls.withArgs(listOf("kek")).run()
+        assertEquals(true, result.isInterrupted)
+        assertEquals("No directory named kek found", result.textResult)
+    }
+
+    @Test
+    fun cdSimpleTest() {
+        val cd = CD(environment)
+
+        file = File("kek")
+        file.mkdir()
+
+        val result = cd.withArgs(listOf("kek")).run()
+        assertEquals(false, result.isInterrupted)
+        assertEquals("", result.textResult)
+        assertEquals(file.canonicalPath, environment.workingDirectory.canonicalPath)
+    }
+
+    @Test
+    fun cdNotExistedSubDirTest() {
+        val cd = CD(environment)
+
+        val result = cd.withArgs(listOf("kek")).run()
+        assertEquals(true, result.isInterrupted)
+        assertEquals("No directory named kek found", result.textResult)
+        assertEquals(File(".").canonicalPath, environment.workingDirectory.canonicalPath)
+    }
 }

--- a/CLI/src/test/kotlin/OperationTest.kt
+++ b/CLI/src/test/kotlin/OperationTest.kt
@@ -1,12 +1,26 @@
 package com.sd.hw
 
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class OperationTest {
-    private val environment = Environment()
+    private lateinit var environment: Environment
+    private var file: File = File("")
+
+    @BeforeEach
+    fun initEnv() {
+        environment = Environment()
+        file = File("")
+    }
+
+    @AfterEach
+    fun deleteFile() {
+        file.delete()
+    }
 
     @Test
     fun pwdSimpleTest() {
@@ -66,9 +80,11 @@ internal class OperationTest {
     @Test
     fun wcFileTest() {
         val wc = WC(environment)
-        val file = File("kek")
+
+        file = File("kek")
         file.createNewFile()
         file.writeText("a a")
+
         val result = wc.withArgs(listOf("kek")).run()
         assertEquals(false, result.isInterrupted)
         assertEquals("1 2 3", result.textResult)
@@ -84,10 +100,11 @@ internal class OperationTest {
     @Test
     fun wcExtraArgsTest() {
         val wc = WC(environment)
-        val file = File("kek")
+
+        file = File("kek")
         file.createNewFile()
         file.writeText("a a")
-        file.deleteOnExit()
+
         val result = wc.withArgs(listOf("kek", "a", "b", "c")).run()
         assertEquals(false, result.isInterrupted)
         assertEquals("1 2 3", result.textResult)
@@ -104,10 +121,10 @@ internal class OperationTest {
     @Test
     fun catExistingFileTest() {
         val cat = Cat(environment)
-        val file = File("kek")
+
+        file = File("kek")
         file.createNewFile()
         file.writeText("a\na\na a a b \nc")
-        file.deleteOnExit()
 
         val result = cat.withArgs(listOf("kek")).run()
         assertEquals(false, result.isInterrupted)

--- a/CLI/src/test/kotlin/OperationTest.kt
+++ b/CLI/src/test/kotlin/OperationTest.kt
@@ -13,7 +13,7 @@ internal class OperationTest {
         val pwd = Pwd(environment)
         val result = pwd.run()
         assertEquals(false, result.isInterrupted)
-        assertEquals(File(".").absolutePath, result.textResult)
+        assertEquals(File(".").canonicalPath, result.textResult)
     }
 
     @Test
@@ -21,7 +21,7 @@ internal class OperationTest {
         val pwd = Pwd(environment)
         val result = pwd.withArgs(listOf("aaa", "bbb", "a")).run()
         assertEquals(false, result.isInterrupted)
-        assertEquals(File(".").absolutePath, result.textResult)
+        assertEquals(File(".").canonicalPath, result.textResult)
     }
 
     @Test
@@ -29,7 +29,7 @@ internal class OperationTest {
         val pwd = Pwd(environment)
         val result = pwd.run("kek")
         assertEquals(false, result.isInterrupted)
-        assertEquals(File(".").absolutePath, result.textResult)
+        assertEquals(File(".").canonicalPath, result.textResult)
     }
 
     @Test

--- a/CLI/src/test/kotlin/ParserTest.kt
+++ b/CLI/src/test/kotlin/ParserTest.kt
@@ -1,8 +1,9 @@
 package com.sd.hw
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
 
 internal class ParserTest {
     private val environment = Environment()


### PR DESCRIPTION
Удобства:
* Хорошо, что вся работа с путями проходила через Environment. Это позволило без лишней боли добавить рабочую директорию.
* Вообще доступ к Environment из команды - это удобно.
* Есть явная возможность указать, что команда отработала неправильно и следует прервать пайплайн
* Простота добавления команд: достаточно отнаследоваться от базового класса и добавить в фабрику 1 строчку. 

Неудобства:
* в архитектуру Environment изначально не заложена возможность смены рабочей директории
* более того все работы с путями делаются через absolute path, что при частых переходах приводило к путям вида `/home/path/./../dir/././.`
* публичный, var, mutable (`var args = mutableListOf`) состояние внутри команды кажется мне ну очень странным решением (хоть мне и не мешало)
* Мне кажется, что лучше разделать проверку корректности агрументов от логики, чтобы не создавать слишком большой и сложный метод run (хотя в данном случае это не страшно)
* Возможно слишком большое количество классов в одном файле. Мне норм, но вот большое количество тестов в одном файле разных классов меня сильно напрягало. Очень неудобно, когда нет возможности запустить только тесты одного класса.
* Тесты в принципе были сломаны (перемешан junit 4 и 5), но это не очень про архитектуру.
* Еще в тестах очень плохо сделана работа с файлами. У меня были проблемы с тем, что тесты не чистили за собой (точнее чистили только при выключении jvm) => все падало только при определенном порядке тестов, а по одному все проходило. Гораздо удобнее, когда есть temp dir в которой ты точно знаешь наполнение + не нужно думать об удалении.

В целом все хорошо и почти все проблемы незначительны (существенные неудобства доставили только тесты).
